### PR TITLE
Fix missing typing-extensions dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     version=get_version(),
     author='Ilya Lebedev',
     author_email='melevir@gmail.com',
-    install_requires=['setuptools'],
+    install_requires=['flake8', 'setuptools', 'typing-extensions'],
     entry_points={
         'flake8.extension': [
             'CCE = flake8_class_attributes_order.checker:ClassAttributesOrderChecker',


### PR DESCRIPTION
Running the following in a clean virtualenv:
```
pip install flake8 flake8_class_attributes_order
flake8
```

Results in an error like the following:
```
File ".../lib/python3.6/site-packages/flake8_class_attributes_order/checker.py", line 4, in <module>
  from typing_extensions import Final
ModuleNotFoundError: No module named 'typing_extensions'
```

This change adds `flake8` and `typing-extensions` as requirements for
this package, fixing this error.