### PR TITLE
Add configurable attributes order

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or not.
 
 After resolving each attribute type, validator checks attributes order.
 
-Here are methods order for non strict validation:
+Default configuration checks for the following order of attributes:
 
 - `__new__`
 - `__init__`
@@ -28,7 +28,34 @@ Here are methods order for non strict validation:
 - other methods
 - private methods
 
-And here are methods order if you have strict validation enabled:
+If the order is broken, validator will report on it.
+
+Besides methods, the validator checks other attributes methods:
+docstrings, nested classes, constants, attributes, and so on.
+
+Also validator checks, if class has no class level logic and report
+if any. Here is an example:
+
+```python
+class PhoneForm(forms.Form):
+    phone = forms.CharField(17, label='Телефон'.upper())
+
+    # this should happen in __init__!
+    phone.widget.attrs.update({'class': 'form-control phone'})
+
+```
+
+## Installation
+
+```
+pip install flake8-class-attributes-order
+```
+
+## Configuration
+
+### Strict mode
+
+There is another preconfigured order that is more strict on private subtypes:
 
 - `__new__`
 - `__init__`
@@ -46,31 +73,65 @@ And here are methods order if you have strict validation enabled:
 To enable strict validation, please set the flag in your config file:
 
 ```
+[flake8]
 use_class_attributes_order_strict_mode = True
 ```
 
-If the order is broken, validator will report on it.
+### Manual order configuration
 
-Besides methods, the validator checks other attributes methods:
-docstrings, nested classes, constants, attributes, and so on.
+Order can be manually configured via `class_attributes_order` config setting.
 
-Also validator checks, if class has no class level logic and report
-if any. Here is an example:
-
-```python
-class PhoneForm(forms.Form):
-    phone = forms.CharField(17, label='Телефон'.upper())
-
-    # this should happens in __init__!
-    phone.widget.attrs.update({'class': 'form-control phone'})
+For example, if you prefer to put `class Meta` after constants and fields:
 
 ```
-
-## Installation
-
+[flake8]
+class_attributes_order =
+    field,
+    meta_class,
+    nested_class,
+    magic_method,
+    property_method,
+    static_method,
+    class_method,
+    method,
+    private_method
 ```
-pip install flake8-class-attributes-order
-```
+
+Configurable options:
+
+| Option                |               Description           | Fallbacks to\* |
+|:---------------------:|:-----------------------------------:|:--------------:|
+|meta_class             |class Meta: (e.g. in Django projects)| nested_class   |
+|nested_class           |Other nested classes                 | None\*         |
+|constant               |SOME_CONSTANTS                       | field          |
+|outer_field            |some = models.ForeignKey etc.        | field          |
+|field                  |Other fields                         | None           |
+|`__new__`              |`__new__`                            | magic_method   |
+|`__init__`             |`__init__`                           | magic_method   |
+|`__post_init__`        |`__post_init__`                      | magic_method   |
+|`__str__`              |`__str__`                            | magic_method   |
+|magic_method           |Other magic methods                  | method         |
+|save                   |def save(...)                        | method         |
+|delete                 |def delete(...)                      | method         |
+|property_method        |@property/@cached_property etc.      | method         |
+|private_property_method|@property/@cached_property with _    | property_method|
+|static_method          |@staticmethod                        | method         |
+|private_static_method  |@staticmethod beginning with _       | static_method  |
+|class_method           |@classmethod                         | method         |
+|private_class_method   |@classmethod beginning with _        | class_method   |
+|private_method         |other methods beginning with _       | method         |
+|method                 |other methods                        | None           |
+
+\* if not provided, will use its supertype order
+
+\*\*  if not defined, such base types and all their subtypes (unless defined)
+will be ignored during validation. It's recommended
+to set at least `nested_class`, `field` and `method`
+
+You choose how detailed your configuration is.
+For example, you can define order of each supported magic method
+(`__new__`, `__str__`, etc.), or set `magic_method`
+to allow any order among them or even just use `method`
 
 ## Example
 

--- a/flake8_class_attributes_order/checker.py
+++ b/flake8_class_attributes_order/checker.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Generator, Tuple, List, Union, Mapping
+from typing import Generator, Tuple, List, Union, Mapping, Dict
 
 from typing_extensions import Final
 
@@ -71,7 +71,7 @@ class ClassAttributesOrderChecker:
         'private_method': 28,
     }
 
-    FIXED_NODE_TYPE_WEIGHTS: Final[Mapping[str, int]] = {
+    FIXED_NODE_TYPE_WEIGHTS: Final[Dict[str, int]] = {
         'docstring': 0,
         'pass': 1,
         'expression': 2,
@@ -297,8 +297,6 @@ class ClassAttributesOrderChecker:
                     if node_type_or_supertype in node_to_configured_weight:
                         node_type_weights[node_type] = node_to_configured_weight[node_type_or_supertype]
                         break
-                else:
-                    node_type_weights[node_type] = None
 
             return node_type_weights
         elif ClassAttributesOrderChecker.use_strict_mode:

--- a/flake8_class_attributes_order/checker.py
+++ b/flake8_class_attributes_order/checker.py
@@ -71,10 +71,46 @@ class ClassAttributesOrderChecker:
         'private_method': 28,
     }
 
+    FIXED_NODE_TYPE_WEIGHTS: Final[Mapping[str, int]] = {
+        'docstring': 0,
+        'pass': 1,
+        'expression': 2,
+        'if': 3,
+    }
+
+    CONFIGURABLE_NODE_TYPES: Final[Mapping[str, List[str]]] = {
+        'nested_class': ['nested_class'],
+        'meta_class': ['meta_class', 'nested_class'],
+
+        'field': ['field'],
+        'constant': ['constant', 'field'],
+        'outer_field': ['outer_field', 'field'],
+
+        'method': ['method'],
+        'magic_method': ['magic_method', 'method'],
+        '__new__': ['__new__', 'magic_method', 'method'],
+        '__init__': ['__init__', 'magic_method', 'method'],
+        '__post_init__': ['__post_init__', 'magic_method', 'method'],
+        '__str__': ['__str__', 'magic_method', 'method'],
+
+        'private_method': ['private_method', 'method'],
+
+        'save': ['save', 'method'],
+        'delete': ['delete', 'method'],
+
+        'property_method': ['property_method', 'method'],
+        'private_property_method': ['private_property_method', 'property_method', 'method'],
+        'static_method': ['static_method', 'method'],
+        'private_static_method': ['private_static_method', 'static_method', 'method'],
+        'class_method': ['class_method', 'method'],
+        'private_class_method': ['private_class_method', 'class_method', 'method'],
+    }
+
     name = 'flake8-class-attributes-order'
     version = version
 
     use_strict_mode = False
+    class_attributes_order = None
 
     def __init__(self, tree, filename: str):
         self.filename = filename
@@ -160,22 +196,29 @@ class ClassAttributesOrderChecker:
             action='store_true',
             parse_from_config=True,
         )
+        parser.add_option(
+            '--class-attributes-order',
+            comma_separated_list=True,
+            parse_from_config=True,
+        )
 
     @classmethod
     def parse_options(cls, options) -> None:
         cls.use_strict_mode = bool(options.use_class_attributes_order_strict_mode)
+        cls.class_attributes_order = options.class_attributes_order
 
     @classmethod
     def _get_model_parts_info(cls, model_ast, weights: Mapping[str, int]):
         parts_info = []
         for child_node in model_ast.body:
             node_type = cls._get_model_node_type(child_node)
-            parts_info.append({
-                'model_name': model_ast.name,
-                'node': child_node,
-                'type': node_type,
-                'weight': weights[node_type],
-            })
+            if node_type in weights:
+                parts_info.append({
+                    'model_name': model_ast.name,
+                    'node': child_node,
+                    'type': node_type,
+                    'weight': weights[node_type],
+                })
         return parts_info
 
     @classmethod
@@ -239,12 +282,32 @@ class ClassAttributesOrderChecker:
                 ))
         return errors
 
+    @classmethod
+    def _get_node_weights(cls) -> Mapping[str, int]:
+        if ClassAttributesOrderChecker.class_attributes_order:
+            node_type_weights = cls.FIXED_NODE_TYPE_WEIGHTS.copy()
+            node_to_configured_weight = {
+                k: v for v, k in enumerate(
+                    ClassAttributesOrderChecker.class_attributes_order,
+                    start=len(node_type_weights))
+            }
+
+            for node_type, node_type_path in cls.CONFIGURABLE_NODE_TYPES.items():
+                for node_type_or_supertype in node_type_path:
+                    if node_type_or_supertype in node_to_configured_weight:
+                        node_type_weights[node_type] = node_to_configured_weight[node_type_or_supertype]
+                        break
+                else:
+                    node_type_weights[node_type] = None
+
+            return node_type_weights
+        elif ClassAttributesOrderChecker.use_strict_mode:
+            return cls.STRICT_NODE_TYPE_WEIGHTS
+        else:
+            return cls.NON_STRICT_NODE_TYPE_WEIGHTS
+
     def run(self) -> Generator[Tuple[int, int, str, type], None, None]:
-        weight_info = (
-            self.STRICT_NODE_TYPE_WEIGHTS
-            if ClassAttributesOrderChecker.use_strict_mode
-            else self.NON_STRICT_NODE_TYPE_WEIGHTS
-        )
+        weight_info = self._get_node_weights()
         classes = [n for n in ast.walk(self.tree) if isinstance(n, ast.ClassDef)]
         errors: List[Tuple[int, int, str]] = []
         for class_def in classes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 import ast
 import os
 
+from flake8.options.manager import OptionManager
+
 from flake8_class_attributes_order.checker import ClassAttributesOrderChecker
 
 
-def run_validator_for_test_file(filename, max_annotations_complexity=None):
+def run_validator_for_test_file(filename, max_annotations_complexity=None,
+                                strict_mode=False, attributes_order=None):
     test_file_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         'test_files',
@@ -13,6 +16,12 @@ def run_validator_for_test_file(filename, max_annotations_complexity=None):
     with open(test_file_path, 'r') as file_handler:
         raw_content = file_handler.read()
     tree = ast.parse(raw_content)
+
+    options = OptionManager()
+    options.use_class_attributes_order_strict_mode = strict_mode
+    options.class_attributes_order = attributes_order
+    ClassAttributesOrderChecker.parse_options(options)
+
     checker = ClassAttributesOrderChecker(tree=tree, filename=filename)
     if max_annotations_complexity:
         checker.max_annotations_complexity = max_annotations_complexity

--- a/tests/test_class_attributes_order.py
+++ b/tests/test_class_attributes_order.py
@@ -1,7 +1,10 @@
+import warnings
+
 from conftest import run_validator_for_test_file
+from flake8.options.manager import OptionManager
 
 
-def test_always_ok_for_empty_file():
+def test_file_with_improper_default_order():
     errors = run_validator_for_test_file('errored.py')
     assert len(errors) == 4
 
@@ -12,3 +15,83 @@ def test_async_def_not_breaks_validator():
 
 def test_ok_cases_produces_no_errors():
     assert not run_validator_for_test_file('ok.py')
+
+
+def test_strict_mode_improper_order():
+    errors = run_validator_for_test_file(
+        'strict_errored.py', strict_mode=True)
+    assert len(errors) == 2
+
+
+def test_strict_mode_no_errors():
+    assert not run_validator_for_test_file(
+        'strict_ok.py', strict_mode=True)
+
+
+def test_configurable_order_correct_order():
+    assert not run_validator_for_test_file(
+        'configurable.py',
+        attributes_order=[
+            'constant',
+            'field',
+            'meta_class',
+            'magic_method',
+            'property_method',
+            'method',
+            'private_method',
+            '__str__',
+        ],
+    )
+
+
+def test_configurable_order_wrong_order():
+    errors = run_validator_for_test_file(
+        'configurable.py',
+        attributes_order=[
+            'field',
+            'constant',
+            'meta_class',
+            'nested_class',
+            'magic_method',
+            'property_method',
+            'method',
+            '__str__',
+            'private_method',
+        ],
+    )
+    assert len(errors) == 2
+
+
+def test_child_attributes_fallback_to_parent_if_not_configured():
+    assert not run_validator_for_test_file(
+        'configurable.py',
+        attributes_order=['field', 'nested_class','method'],
+    )
+    errors = run_validator_for_test_file(
+        'configurable.py',
+        attributes_order=['nested_class', 'field', 'method'],
+    )
+    assert len(errors) == 1
+
+
+def test_ignore_base_attribute_and_subattributes_if_not_configured():
+    errors = run_validator_for_test_file(
+        'configurable.py',
+        attributes_order=['property_method', 'private_property_method'],
+    )
+    assert len(errors) == 1
+
+
+def test_always_require_fixed_attributes():
+    errors = run_validator_for_test_file(
+        'late_docstring.py',
+        attributes_order=['field', 'method'],
+    )
+    assert len(errors) == 1
+
+
+def test_warning_if_both_strict_mode_and_configurable_order_defined():
+    with warnings.catch_warnings(record=True) as w:
+        run_validator_for_test_file(
+            'ok.py', strict_mode=True, attributes_order=['nested_class', 'field', 'method'])
+        assert len(w) == 1

--- a/tests/test_files/configurable.py
+++ b/tests/test_files/configurable.py
@@ -1,0 +1,29 @@
+
+
+class Foo:
+    CONSTANT = 42
+
+    field = 17
+
+    class Meta:
+        a = 3
+
+    def __init__(self):
+        ...
+
+    @property
+    def _egg(self):
+        ...
+
+    @property
+    def egg(self):
+        ...
+
+    def bar(self):
+        ...
+
+    def _bar(self):
+        ...
+
+    def __str__(self):
+        ...

--- a/tests/test_files/late_docstring.py
+++ b/tests/test_files/late_docstring.py
@@ -1,0 +1,8 @@
+
+class Foo:
+    CONSTANT = 42
+
+    def bar():
+        ...
+
+    """Oh, really?"""

--- a/tests/test_files/strict_errored.py
+++ b/tests/test_files/strict_errored.py
@@ -1,0 +1,30 @@
+
+
+class Foo:
+    CONSTANT = True
+
+    @property
+    def _bar(self):
+        ...
+
+    @property
+    def bar(self):
+        ...
+
+    # It's ok with static methods
+    @staticmethod
+    def egg():
+        ...
+
+    @staticmethod
+    def _egg():
+        ...
+
+
+    @classmethod
+    def _foobar(cls):
+        ...
+
+    @classmethod
+    def foobar(cls):
+        ...

--- a/tests/test_files/strict_ok.py
+++ b/tests/test_files/strict_ok.py
@@ -1,0 +1,37 @@
+
+
+class Foo:
+
+    class Meta:
+        a = 3
+
+    CONSTANT = True
+
+    def __init__():
+        ...
+
+    @property
+    def bar(self):
+        ...
+
+    @property
+    def _bar(self):
+        ...
+
+
+    @staticmethod
+    def egg():
+        ...
+
+    @staticmethod
+    def _egg():
+        ...
+
+
+    @classmethod
+    def foobar(cls):
+        ...
+
+    @classmethod
+    def _foobar(cls):
+        ...


### PR DESCRIPTION
closes #8

Added support of manually configurable attributes ordering such as:

```
[flake8]
class_attributes_order =
    field,
    meta_class,
    nested_class,
    magic_method,
    property_method,
    static_method,
    class_method,
    method,
    private_method
```

While trying to make it flexible (e.g. not to force users to set all the node types manually), I'm still not sure that my solution is permissible in terms of performance, but looks like it works fine and still no additional complexity was added to "default" and "strict" modes

Any improvement suggestions are accepted with pleasure

